### PR TITLE
It has been two years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020, Ravy
+Copyright (c) 2022, Ravy
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # hst.sh
 
+*This contains the hst.sh script, adapted from [diethnis' hastebin standalone sh script](https://github.com/diethnis/standalones).*
+
 ## Install
 
 `curl -sfL get.hst.sh | bash`
 
-You need `curl` to install and use hst. If you don't have it, the install usually looks like `apt install curl -y`, `pacman -S curl`, or similar. The binary will be saved to /usr/bin/hst - make sure you have the sufficient access permissions.
+You need `curl` to install and use hst.
+
+The binary will be saved to ~/.local/bin/hst - make sure it's in your $PATH.
 
 ## Usage
 
@@ -14,16 +18,10 @@ Some examples:
 
 `echo $PWD | hst`
 
-`hst /etc/nginx/sites-enabled/ravy.pink.conf`
+`hst /etc/nginx/sites-enabled/ravy.org`
 
 ## Why
 
-I found all other haste clients too hard to install or requiring too many dependencies (especially the official one).
+Using hastebin shouldn't be a hassle.
 
-This just makes it a one-liner and doesn't require anything apart from bash, inbuilt commands, and curl.
-
-## Credit where it's due
-
-This contains the hst.sh script, adapted from [diethnis' hastebin standalone sh script](https://github.com/diethnis/standalones).
-
-The original is licensed under The Unlicense.
+This just makes it a one-liner and doesn't require anything apart from bash and curl.

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-curl -sfL https://sh.hst.sh > /usr/bin/hst
-chmod +x /usr/bin/hst
+curl -sfL https://sh.hst.sh > $HOME/.local/bin/hst
+chmod +x $HOME/.local/bin/hst


### PR DESCRIPTION
Bring the hst.sh "binary" repo up to date, which entails:
- 2022 copyright year
- having learnt that installing stuff globally isn't a good idea
- being condescending in the readme isn't either